### PR TITLE
feat(ai_sed): implement sed substitute clone in Go

### DIFF
--- a/ai_sed/Dockerfile
+++ b/ai_sed/Dockerfile
@@ -1,3 +1,10 @@
-FROM python:3.12-alpine
-COPY sed.py /usr/local/bin/sed.py
-ENTRYPOINT ["python3", "/usr/local/bin/sed.py"]
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/ai_sed .
+
+FROM scratch
+COPY --from=build /out/ai_sed /ai_sed
+ENTRYPOINT ["/ai_sed"]

--- a/ai_sed/go.mod
+++ b/ai_sed/go.mod
@@ -1,0 +1,5 @@
+module github.com/marcnuri-demo/20260428-hacknight-ai-hackathon/ai_sed
+
+go 1.26
+
+require github.com/spf13/pflag v1.0.6

--- a/ai_sed/go.sum
+++ b/ai_sed/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/ai_sed/main.go
+++ b/ai_sed/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	pflag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: ai_sed 's/PATTERN/REPLACEMENT/[g]'")
+	}
+	pflag.Parse()
+	args := pflag.Args()
+	if len(args) != 1 {
+		pflag.Usage()
+		os.Exit(2)
+	}
+	sub, err := parseSubstitute(args[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ai_sed:", err)
+		os.Exit(1)
+	}
+	if err := run(sub, os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "ai_sed:", err)
+		os.Exit(1)
+	}
+}
+
+func run(sub *substitute, in io.Reader, out io.Writer) error {
+	r := bufio.NewReader(in)
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			hadNewline := false
+			if line[len(line)-1] == '\n' {
+				line = line[:len(line)-1]
+				hadNewline = true
+			}
+			if _, werr := w.WriteString(sub.apply(line)); werr != nil {
+				return werr
+			}
+			if hadNewline {
+				if werr := w.WriteByte('\n'); werr != nil {
+					return werr
+				}
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/ai_sed/sed.py
+++ b/ai_sed/sed.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-import sys
-
-for line in sys.stdin:
-    sys.stdout.write(line)

--- a/ai_sed/substitute.go
+++ b/ai_sed/substitute.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type substitute struct {
+	re     *regexp.Regexp
+	repl   []replPart
+	global bool
+}
+
+type replPart struct {
+	literal string
+	group   int // -1 = literal, 0 = whole match (&), 1..9 = backreference
+}
+
+func parseSubstitute(script string) (*substitute, error) {
+	if len(script) < 2 || script[0] != 's' {
+		return nil, fmt.Errorf("only 's' command supported")
+	}
+	delim := script[1]
+	if delim != '/' {
+		return nil, fmt.Errorf("only '/' delimiter supported")
+	}
+	parts, err := splitScript(script[2:], delim)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("malformed substitute: expected s/PATTERN/REPLACEMENT/FLAGS")
+	}
+	rePat, err := bre2re2(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	re, err := regexp.Compile(rePat)
+	if err != nil {
+		return nil, fmt.Errorf("compile regex %q: %w", parts[0], err)
+	}
+	repl, err := parseReplacement(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	sub := &substitute{re: re, repl: repl}
+	for _, c := range parts[2] {
+		switch c {
+		case 'g':
+			sub.global = true
+		default:
+			return nil, fmt.Errorf("flag %q not supported", c)
+		}
+	}
+	return sub, nil
+}
+
+func splitScript(s string, delim byte) ([]string, error) {
+	var parts []string
+	var cur strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\\' && i+1 < len(s) {
+			cur.WriteByte('\\')
+			cur.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		if c == delim {
+			parts = append(parts, cur.String())
+			cur.Reset()
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	parts = append(parts, cur.String())
+	return parts, nil
+}
+
+// bre2re2 translates a POSIX Basic Regular Expression into RE2 syntax.
+// Handled BRE features: \(...\), \{m,n\}, \+, \?, ^/$ anchors at start/end of
+// pattern, ., *, [...], [^...], POSIX [:class:], \n, \t, \\, \/.
+func bre2re2(bre string) (string, error) {
+	var out strings.Builder
+	for i := 0; i < len(bre); {
+		c := bre[i]
+		switch c {
+		case '\\':
+			if i+1 >= len(bre) {
+				return "", fmt.Errorf("trailing backslash in pattern")
+			}
+			next := bre[i+1]
+			switch next {
+			case '(', ')', '{', '}', '+', '?', '|':
+				out.WriteByte(next)
+			case '\\':
+				out.WriteString(`\\`)
+			case '/':
+				out.WriteByte('/')
+			case '.', '*', '^', '$', '[', ']':
+				out.WriteByte('\\')
+				out.WriteByte(next)
+			case 'n':
+				out.WriteString(`\n`)
+			case 't':
+				out.WriteString(`\t`)
+			case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				return "", fmt.Errorf("backreferences in pattern not supported")
+			default:
+				if isRE2Meta(next) {
+					out.WriteByte('\\')
+				}
+				out.WriteByte(next)
+			}
+			i += 2
+		case '[':
+			end, err := findCharClassEnd(bre, i)
+			if err != nil {
+				return "", err
+			}
+			out.WriteString(bre[i : end+1])
+			i = end + 1
+		case '(', ')', '{', '}', '+', '?', '|':
+			out.WriteByte('\\')
+			out.WriteByte(c)
+			i++
+		case '^':
+			if i == 0 {
+				out.WriteByte('^')
+			} else {
+				out.WriteString(`\^`)
+			}
+			i++
+		case '$':
+			if i == len(bre)-1 {
+				out.WriteByte('$')
+			} else {
+				out.WriteString(`\$`)
+			}
+			i++
+		default:
+			out.WriteByte(c)
+			i++
+		}
+	}
+	return out.String(), nil
+}
+
+func findCharClassEnd(s string, start int) (int, error) {
+	i := start + 1
+	if i < len(s) && s[i] == '^' {
+		i++
+	}
+	if i < len(s) && s[i] == ']' {
+		i++
+	}
+	for i < len(s) {
+		if s[i] == '[' && i+1 < len(s) && s[i+1] == ':' {
+			j := i + 2
+			for j+1 < len(s) && !(s[j] == ':' && s[j+1] == ']') {
+				j++
+			}
+			if j+1 >= len(s) {
+				return 0, fmt.Errorf("unclosed POSIX character class")
+			}
+			i = j + 2
+			continue
+		}
+		if s[i] == ']' {
+			return i, nil
+		}
+		i++
+	}
+	return 0, fmt.Errorf("unclosed character class")
+}
+
+func isRE2Meta(c byte) bool {
+	switch c {
+	case '\\', '.', '+', '*', '?', '(', ')', '|', '[', ']', '{', '}', '^', '$':
+		return true
+	}
+	return false
+}
+
+func parseReplacement(s string) ([]replPart, error) {
+	var parts []replPart
+	var lit strings.Builder
+	flush := func() {
+		if lit.Len() > 0 {
+			parts = append(parts, replPart{literal: lit.String(), group: -1})
+			lit.Reset()
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\\' {
+			if i+1 >= len(s) {
+				return nil, fmt.Errorf("trailing backslash in replacement")
+			}
+			next := s[i+1]
+			switch next {
+			case '&', '\\', '/':
+				lit.WriteByte(next)
+			case 'n':
+				lit.WriteByte('\n')
+			case 't':
+				lit.WriteByte('\t')
+			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				flush()
+				parts = append(parts, replPart{group: int(next - '0')})
+			default:
+				lit.WriteByte(next)
+			}
+			i++
+			continue
+		}
+		if c == '&' {
+			flush()
+			parts = append(parts, replPart{group: 0})
+			continue
+		}
+		lit.WriteByte(c)
+	}
+	flush()
+	return parts, nil
+}
+
+func (s *substitute) apply(line string) string {
+	if !s.global {
+		loc := s.re.FindStringSubmatchIndex(line)
+		if loc == nil {
+			return line
+		}
+		var out strings.Builder
+		out.WriteString(line[:loc[0]])
+		out.WriteString(s.expand(line, loc))
+		out.WriteString(line[loc[1]:])
+		return out.String()
+	}
+	matches := s.re.FindAllStringSubmatchIndex(line, -1)
+	if matches == nil {
+		return line
+	}
+	var out strings.Builder
+	last := 0
+	for _, loc := range matches {
+		out.WriteString(line[last:loc[0]])
+		out.WriteString(s.expand(line, loc))
+		last = loc[1]
+	}
+	out.WriteString(line[last:])
+	return out.String()
+}
+
+func (s *substitute) expand(line string, loc []int) string {
+	var out strings.Builder
+	for _, p := range s.repl {
+		if p.group < 0 {
+			out.WriteString(p.literal)
+			continue
+		}
+		idx := p.group * 2
+		if idx+1 >= len(loc) || loc[idx] < 0 {
+			continue
+		}
+		out.WriteString(line[loc[idx]:loc[idx+1]])
+	}
+	return out.String()
+}

--- a/ai_sed/test/blackbox_test.go
+++ b/ai_sed/test/blackbox_test.go
@@ -1,0 +1,159 @@
+package blackbox_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var (
+	binOnce sync.Once
+	binPath string
+	binErr  error
+)
+
+func aiSedBinary(t *testing.T) string {
+	t.Helper()
+	binOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "ai_sed_bin_*")
+		if err != nil {
+			binErr = err
+			return
+		}
+		binPath = filepath.Join(dir, "ai_sed")
+		cmd := exec.Command("go", "build", "-o", binPath, "..")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			binErr = err
+		}
+	})
+	if binErr != nil {
+		t.Fatalf("build ai_sed: %v", binErr)
+	}
+	return binPath
+}
+
+func mustRun(t *testing.T, name string, args []string, input string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s %v: %v\nstderr: %s", name, args, err, errb.String())
+	}
+	return out.String()
+}
+
+func errorLines(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("../../server.log")
+	if err != nil {
+		t.Fatalf("read server.log: %v", err)
+	}
+	var b strings.Builder
+	for _, line := range strings.SplitAfter(string(data), "\n") {
+		if strings.Contains(line, "ERROR") {
+			b.WriteString(line)
+		}
+	}
+	return b.String()
+}
+
+func TestSubstituteScenarios(t *testing.T) {
+	bin := aiSedBinary(t)
+
+	cases := []struct {
+		name   string
+		script string
+		input  string
+	}{
+		{
+			name:   "simple substitute without g",
+			script: "s/foo/bar/",
+			input:  "foofoo\nfoo bar foo\nno match\n",
+		},
+		{
+			name:   "substitute with g",
+			script: "s/foo/bar/g",
+			input:  "foofoo\nfoo bar foo\nno match\n",
+		},
+		{
+			name:   "README capture groups",
+			script: `s/.*\[user=\([^]]*\)\] - \(.*\)/\2|\1/`,
+			input:  errorLines(t),
+		},
+		{
+			name:   "README strip after pipe",
+			script: "s/|.*//",
+			input:  "Authentication token expired|user020\nNullPointerException in main thread|user003\nno pipe here\n",
+		},
+		{
+			name:   "no match passthrough",
+			script: "s/zzz/xxx/",
+			input:  "abc\ndef\nghi\n",
+		},
+		{
+			name:   "empty input",
+			script: "s/foo/bar/g",
+			input:  "",
+		},
+		{
+			name:   "input without trailing newline",
+			script: "s/foo/bar/",
+			input:  "foofoo",
+		},
+		{
+			name:   "ampersand in replacement",
+			script: "s/foo/[&]/g",
+			input:  "foofoo bar foo\n",
+		},
+		{
+			name:   "escaped ampersand in replacement",
+			script: `s/foo/x\&y/`,
+			input:  "foo\n",
+		},
+		{
+			name:   "anchors mid-pattern are literal",
+			script: "s/a^b/X/",
+			input:  "a^b\nab\n",
+		},
+		{
+			name:   "backslash in input",
+			script: `s/\\/X/g`,
+			input:  "a\\b\\c\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustRun(t, bin, []string{tc.script}, tc.input)
+			want := mustRun(t, "sed", []string{tc.script}, tc.input)
+			if got != want {
+				t.Errorf("output mismatch\nscript: %s\nwant: %q\n got: %q", tc.script, want, got)
+			}
+		})
+	}
+}
+
+func TestPipelineProblem2(t *testing.T) {
+	bin := aiSedBinary(t)
+	input := errorLines(t)
+
+	want := mustRun(t, "sed", []string{`s/.*\[user=\([^]]*\)\] - \(.*\)/\2|\1/`}, input)
+	got := mustRun(t, bin, []string{`s/.*\[user=\([^]]*\)\] - \(.*\)/\2|\1/`}, input)
+	if got != want {
+		t.Fatalf("first sed stage mismatch")
+	}
+
+	want2 := mustRun(t, "sed", []string{"s/|.*//"}, want)
+	got2 := mustRun(t, bin, []string{"s/|.*//"}, got)
+	if got2 != want2 {
+		t.Fatalf("second sed stage mismatch")
+	}
+}

--- a/ai_sed/test/blackbox_test.go
+++ b/ai_sed/test/blackbox_test.go
@@ -2,6 +2,7 @@ package blackbox_test
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -136,6 +137,101 @@ func TestSubstituteScenarios(t *testing.T) {
 			want := mustRun(t, "sed", []string{tc.script}, tc.input)
 			if got != want {
 				t.Errorf("output mismatch\nscript: %s\nwant: %q\n got: %q", tc.script, want, got)
+			}
+		})
+	}
+}
+
+func runWithStatus(t *testing.T, name string, args []string, input string) (stdout, stderr string, exit int) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return outb.String(), errb.String(), ee.ExitCode()
+		}
+		t.Fatalf("%s %v: %v", name, args, err)
+	}
+	return outb.String(), errb.String(), 0
+}
+
+func TestSubstituteErrors(t *testing.T) {
+	bin := aiSedBinary(t)
+
+	cases := []struct {
+		name      string
+		args      []string
+		input     string
+		stderrSub string
+	}{
+		{
+			name:      "non-substitute command rejected",
+			args:      []string{"d"},
+			stderrSub: "only 's' command supported",
+		},
+		{
+			name:      "non-slash delimiter rejected",
+			args:      []string{"s|foo|bar|"},
+			stderrSub: "only '/' delimiter supported",
+		},
+		{
+			name:      "missing trailing delimiter rejected",
+			args:      []string{"s/foo/bar"},
+			stderrSub: "malformed substitute",
+		},
+		{
+			name:      "incomplete script rejected",
+			args:      []string{"s/foo"},
+			stderrSub: "malformed substitute",
+		},
+		{
+			name:      "unsupported flag rejected",
+			args:      []string{"s/foo/bar/x"},
+			stderrSub: "not supported",
+		},
+		{
+			name:      "backreference in pattern rejected",
+			args:      []string{`s/\(foo\)\1/x/`},
+			stderrSub: "backreferences in pattern not supported",
+		},
+		{
+			name:      "trailing backslash in replacement rejected",
+			args:      []string{`s/foo/bar\/`},
+			stderrSub: "malformed substitute",
+		},
+		{
+			name:      "empty script rejected",
+			args:      []string{""},
+			stderrSub: "only 's' command supported",
+		},
+		{
+			name:      "no positional argument exits with usage",
+			args:      []string{},
+			stderrSub: "usage:",
+		},
+		{
+			name:      "two positional arguments rejected",
+			args:      []string{"s/a/b/", "extra"},
+			stderrSub: "usage:",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exit := runWithStatus(t, bin, tc.args, tc.input)
+			if exit == 0 {
+				t.Fatalf("expected non-zero exit, got 0\nstdout: %q\nstderr: %q", stdout, stderr)
+			}
+			if !strings.Contains(stderr, tc.stderrSub) {
+				t.Errorf("stderr does not contain %q\nstderr: %q", tc.stderrSub, stderr)
+			}
+			if stdout != "" {
+				t.Errorf("expected empty stdout on error, got %q", stdout)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replace the Python placeholder in `ai_sed/` with a Go implementation of `sed s/PATTERN/REPLACEMENT/[g]`.
- Translate POSIX BRE patterns (`\(...\)`, `\{m,n\}`, `\+`, `\?`, `^`/`$` anchors, `[...]`) into RE2; expand `&`, `\&`, `\0`–`\9` backreferences in the replacement.
- Ship as a multi-stage Docker image (`golang:1.26-alpine` → `scratch`); flag parsing via `github.com/spf13/pflag` per `CLAUDE.md`.
- Black-box tests under `ai_sed/test/` build the real binary and pipe inputs through both it and the system's native `sed`, asserting byte-identical stdout — no mocks/stubs/fakes.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 11 black-box scenarios pass, covering all six AC cases plus `&`, escaped `\&`, mid-pattern anchors, backslash in input, and no-trailing-newline EOF
- [x] `podman build -t ai_sed ai_sed` — image builds to scratch
- [x] README Problem 2 full pipeline (native vs AI sed swapped in) — byte-identical
- [x] README Problem 3 full pipeline (with hours filter) — byte-identical

Closes #2