### PR TITLE
feat(ai_uniq): implement Go-based GNU uniq clone

### DIFF
--- a/ai_uniq/Dockerfile
+++ b/ai_uniq/Dockerfile
@@ -1,3 +1,10 @@
-FROM python:3.12-alpine
-COPY uniq.py /usr/local/bin/uniq.py
-ENTRYPOINT ["python3", "/usr/local/bin/uniq.py"]
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY main.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/ai_uniq .
+
+FROM scratch
+COPY --from=build /out/ai_uniq /ai_uniq
+ENTRYPOINT ["/ai_uniq"]

--- a/ai_uniq/go.mod
+++ b/ai_uniq/go.mod
@@ -1,0 +1,5 @@
+module github.com/marcnuri-demo/20260428-hacknight-ai-hackathon/ai_uniq
+
+go 1.23
+
+require github.com/spf13/pflag v1.0.10

--- a/ai_uniq/go.sum
+++ b/ai_uniq/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/ai_uniq/main.go
+++ b/ai_uniq/main.go
@@ -1,0 +1,79 @@
+// ai_uniq — minimal stdin/stdout clone of GNU uniq.
+//
+// Scope (per issue #4): collapse adjacent duplicate lines (default) and emit
+// counts in GNU's `%7d %s\n` format under `-c`. No file args, no other flags.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	count := pflag.BoolP("count", "c", false, "prefix lines by the number of occurrences")
+	pflag.Parse()
+	if err := run(os.Stdin, os.Stdout, *count); err != nil {
+		fmt.Fprintln(os.Stderr, "ai_uniq:", err)
+		os.Exit(1)
+	}
+}
+
+// run reads `in`, collapses adjacent duplicate lines, and writes results to
+// `out`. Output is always `\n`-terminated, matching GNU uniq's normalization
+// even when the input's final line lacks a terminator.
+func run(in io.Reader, out io.Writer, count bool) error {
+	r := bufio.NewReader(in)
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+
+	var prev string
+	var have bool
+	var n uint64
+
+	emit := func() error {
+		if !have {
+			return nil
+		}
+		if count {
+			_, err := fmt.Fprintf(w, "%7d %s\n", n, prev)
+			return err
+		}
+		if _, err := w.WriteString(prev); err != nil {
+			return err
+		}
+		_, err := w.WriteString("\n")
+		return err
+	}
+
+	for {
+		line, err := r.ReadString('\n')
+		if line != "" || err == nil {
+			content := line
+			if len(content) > 0 && content[len(content)-1] == '\n' {
+				content = content[:len(content)-1]
+			}
+			switch {
+			case !have:
+				prev, n, have = content, 1, true
+			case content == prev:
+				n++
+			default:
+				if err := emit(); err != nil {
+					return err
+				}
+				prev, n = content, 1
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+	}
+	return emit()
+}

--- a/ai_uniq/main.go
+++ b/ai_uniq/main.go
@@ -25,10 +25,14 @@ func main() {
 // run reads `in`, collapses adjacent duplicate lines, and writes results to
 // `out`. Output is always `\n`-terminated, matching GNU uniq's normalization
 // even when the input's final line lacks a terminator.
-func run(in io.Reader, out io.Writer, count bool) error {
+func run(in io.Reader, out io.Writer, count bool) (retErr error) {
 	r := bufio.NewReader(in)
 	w := bufio.NewWriter(out)
-	defer w.Flush()
+	defer func() {
+		if err := w.Flush(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	var prev string
 	var have bool

--- a/ai_uniq/test/uniq_test.go
+++ b/ai_uniq/test/uniq_test.go
@@ -40,12 +40,12 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(tmp)
 	binPath = filepath.Join(tmp, "ai_uniq")
 
 	build := exec.Command("go", "build", "-o", binPath, ".")
 	build.Dir = toolDir
 	if out, err := build.CombinedOutput(); err != nil {
+		os.RemoveAll(tmp)
 		panic("go build failed: " + err.Error() + "\n" + string(out))
 	}
 
@@ -57,7 +57,9 @@ func TestMain(m *testing.M) {
 		gnuUniq = true
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	os.RemoveAll(tmp)
+	os.Exit(code)
 }
 
 // pipe runs cmdName with args, feeding `input` on stdin, and returns stdout.

--- a/ai_uniq/test/uniq_test.go
+++ b/ai_uniq/test/uniq_test.go
@@ -1,0 +1,208 @@
+// Black-box behavioral tests for ai_uniq.
+//
+// These tests build the real ai_uniq binary, pipe real input through it AND
+// through the system's native `uniq`, and assert byte-identical stdout.
+// No mocks, no stubs, no fakes.
+//
+// The `-c` output format is pinned to GNU (`%7d %s\n`). macOS/BSD `uniq -c`
+// uses a 4-wide prefix, so on BSD systems the `-c` byte-identity subtests
+// skip. CI runs on Linux (GNU) and exercises every case.
+package test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var (
+	binPath  string
+	gnuUniq  bool
+	repoRoot string
+)
+
+func TestMain(m *testing.M) {
+	// Resolve repo paths from this test file's location so `go test ./...`
+	// works regardless of cwd.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("could not resolve test file path")
+	}
+	testDir := filepath.Dir(thisFile)
+	toolDir := filepath.Dir(testDir)
+	repoRoot = filepath.Dir(toolDir)
+
+	tmp, err := os.MkdirTemp("", "ai_uniq_bin_")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmp)
+	binPath = filepath.Join(tmp, "ai_uniq")
+
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Dir = toolDir
+	if out, err := build.CombinedOutput(); err != nil {
+		panic("go build failed: " + err.Error() + "\n" + string(out))
+	}
+
+	// Detect GNU uniq once (7-wide right-aligned `-c` prefix).
+	probe := exec.Command("uniq", "-c")
+	probe.Stdin = strings.NewReader("a\na\n")
+	out, err := probe.Output()
+	if err == nil && bytes.HasPrefix(out, []byte("      2 a")) {
+		gnuUniq = true
+	}
+
+	os.Exit(m.Run())
+}
+
+// pipe runs cmdName with args, feeding `input` on stdin, and returns stdout.
+func pipe(t *testing.T, cmdName, input string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command(cmdName, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s %v failed: %v\nstderr: %s", cmdName, args, err, stderr.String())
+	}
+	return stdout.Bytes()
+}
+
+func assertBytesEq(t *testing.T, ai, native []byte, label string) {
+	t.Helper()
+	if !bytes.Equal(ai, native) {
+		t.Fatalf("%s: ai_uniq output differs from native uniq.\n--- ai (%d bytes) ---\n%q\n--- native (%d bytes) ---\n%q",
+			label, len(ai), ai, len(native), native)
+	}
+}
+
+// checkPair runs the input through ai_uniq and through native uniq with the
+// same args and asserts byte-identity. `-c` runs are skipped when native
+// uniq is BSD.
+func checkPair(t *testing.T, name, input string, args ...string) {
+	t.Helper()
+	t.Run(name+"/default", func(t *testing.T) {
+		ai := pipe(t, binPath, input)
+		native := pipe(t, "uniq", input)
+		assertBytesEq(t, ai, native, name+" default")
+	})
+	t.Run(name+"/count", func(t *testing.T) {
+		if !gnuUniq {
+			t.Skip("native uniq is not GNU; skipping -c byte-identity check")
+		}
+		ai := pipe(t, binPath, input, "-c")
+		native := pipe(t, "uniq", input, "-c")
+		assertBytesEq(t, ai, native, name+" -c")
+	})
+	_ = args // reserved for future flag combos; default + -c are the contract
+}
+
+func TestAdjacentDuplicatesCollapsed(t *testing.T) {
+	checkPair(t, "mixed", "a\na\nb\nb\nb\nc\na\na\n")
+}
+
+func TestEmptyInput(t *testing.T) {
+	checkPair(t, "empty", "")
+}
+
+func TestSingleLine(t *testing.T) {
+	checkPair(t, "single", "only\n")
+}
+
+func TestNoDuplicates(t *testing.T) {
+	checkPair(t, "no-dupes", "a\nb\nc\nd\ne\n")
+}
+
+func TestAllDuplicates(t *testing.T) {
+	checkPair(t, "all-dupes", "same\nsame\nsame\nsame\nsame\n")
+}
+
+// Regression: GNU uniq normalizes output to be `\n`-terminated even when the
+// final input line lacked a terminator. An earlier draft propagated the
+// missing terminator instead. BSD uniq preserves the missing terminator —
+// since our contract is GNU, this test runs only against GNU.
+func TestUnterminatedFinalLine(t *testing.T) {
+	if !gnuUniq {
+		t.Skip("native uniq is not GNU; trailing-newline normalization differs")
+	}
+	for _, tc := range []struct{ name, input string }{
+		{"no-trailing-newline", "a\nb"},
+		{"single-no-newline", "a"},
+		{"dupes-no-trailing", "a\na"},
+	} {
+		t.Run(tc.name+"/default", func(t *testing.T) {
+			ai := pipe(t, binPath, tc.input)
+			native := pipe(t, "uniq", tc.input)
+			assertBytesEq(t, ai, native, tc.name+" default")
+		})
+		t.Run(tc.name+"/count", func(t *testing.T) {
+			ai := pipe(t, binPath, tc.input, "-c")
+			native := pipe(t, "uniq", tc.input, "-c")
+			assertBytesEq(t, ai, native, tc.name+" -c")
+		})
+	}
+}
+
+func TestBlankLines(t *testing.T) {
+	checkPair(t, "blank-lines", "\n\n\nfoo\nfoo\n")
+}
+
+// Regression: lines exceeding bufio's initial buffer must be read whole.
+// bufio.Reader.ReadString grows as needed; bufio.Scanner would not.
+func TestVeryLongLine(t *testing.T) {
+	long := strings.Repeat("x", 200_000)
+	input := long + "\n" + long + "\nshort\n"
+	checkPair(t, "very-long-line", input)
+}
+
+func TestCountMixedDigitWidths(t *testing.T) {
+	if !gnuUniq {
+		t.Skip("native uniq is not GNU; skipping -c byte-identity check")
+	}
+	var b strings.Builder
+	b.WriteString("alpha\n")
+	for i := 0; i < 12; i++ {
+		b.WriteString("beta\n")
+	}
+	for i := 0; i < 123; i++ {
+		b.WriteString("gamma\n")
+	}
+	b.WriteString("delta\n")
+	ai := pipe(t, binPath, b.String(), "-c")
+	native := pipe(t, "uniq", b.String(), "-c")
+	assertBytesEq(t, ai, native, "-c mixed widths")
+}
+
+// errorTypesSorted produces the same input shape that feeds `uniq` in
+// README Problem 1: server.log -> grep ERROR -> grep -oE -> sort. We use
+// native helpers for the prefix so this test stays a uniq-specific check
+// (the end-to-end Problem 1 diff is enforced by CI's validate.sh).
+func errorTypesSorted(t *testing.T) string {
+	t.Helper()
+	logBytes, err := os.ReadFile(filepath.Join(repoRoot, "server.log"))
+	if err != nil {
+		t.Fatalf("read server.log: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", `grep "ERROR" | grep -oE "[A-Za-z ]+$" | sort`)
+	cmd.Stdin = bytes.NewReader(logBytes)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("error-types pipeline failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return stdout.String()
+}
+
+func TestReadmePipelineErrorTypes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+	checkPair(t, "readme-error-types", errorTypesSorted(t))
+}

--- a/ai_uniq/uniq.py
+++ b/ai_uniq/uniq.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-import sys
-
-for line in sys.stdin:
-    sys.stdout.write(line)


### PR DESCRIPTION
## Summary
- Replaces the Python `ai_uniq` placeholder with a Go module that mirrors GNU `uniq` for the two flags this repo's pipelines need: default (collapse adjacent dupes) and `-c` (`%7d %s\n` count prefix). Output is `\n`-normalized to match GNU even when the final input line lacks a terminator.
- Multi-stage Dockerfile builds the static binary into `scratch` (~1.7 MB final image). Flags parsed via `github.com/spf13/pflag`.
- Black-box behavioral tests under `ai_uniq/test/`: real built binary piped against real native `uniq`, byte-identical stdout, no mocks/stubs/fakes. `-c` and unterminated-input subtests skip on BSD (where native `uniq` diverges from GNU); CI runs on Linux/GNU and exercises every case.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` green on macOS (BSD-divergent subtests skip, the rest pass)
- [x] Byte-identity verified against GNU (`guniq`) on macOS for: default, `-c`, empty, single-line, no-dupes, all-dupes, unterminated final line, blank lines, lines >200k chars, mixed digit-width counts
- [x] `podman build -t ai_uniq ai_uniq` succeeds; resulting image is ~1.7 MB scratch
- [x] End-to-end Problem 1 against `server.log`: `diff <(native pipeline with guniq) <(AI pipeline with ai_uniq container)` is empty
- [ ] CI green (Linux/GNU exercises the full suite including `-c` and unterminated-input cases)

Closes #4